### PR TITLE
hotfix: override base admin html

### DIFF
--- a/jet/templates/admin/base_site.html
+++ b/jet/templates/admin/base_site.html
@@ -1,0 +1,9 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+
+{% block nav-global %}{% endblock %}


### PR DESCRIPTION
django 在 4.2 之後加上了切換 theme 的功能

https://github.com/django/django/commit/bc7aa2a5e91cf65fc7510edaf1776528c7ad07b4#diff-45dc244a311002fe99ac6540a2adb93b8faeb46107ca0ab04cf483fde9c887caR7

但該功能在原本的 repository 還沒有修正問題

https://github.com/assem-ch/django-jet-reboot/issues/81

Issue 中的方式又會需要要求每個引用的專案加上對應 Url，我認為這樣對於之後使用的人會造成不便
加上該項功能在套用 jet 後其實都會被 jet 給覆寫（例如 base.html 在 jet 會因為有寫自己的 base.html，所以不會有跑版問題）
所以我選擇建立一份 base_site.html 並且放原本 4.2 版本以前的 html
使 jet 在引用 base_site.html 時不會有 4.2 版後多出來的切換部分